### PR TITLE
Add domains for lando usage, and host file script for phpunit tests.

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -9,8 +9,17 @@ proxy:
     - mail.localgov-micro.lndo.site
   adminer:
     - adminer.localgov-micro.lndo.site
+  appserver:
+    - localgov-micro.lndo.site
+    - localgov-micro-1.lndo.site
+    - localgov-micro-2.lndo.site
+    - localgov-micro-3.lndo.site
+    - localgov-micro-4.lndo.site
+    - localgov-micro-5.lndo.site
 services:
   appserver:
+    run_as_root:
+      - 'bash /app/web/modules/contrib/domain_group/define_subdomains.sh'
     overrides:
       environment:
         DRUSH_OPTIONS_ROOT: '/app/web'

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,12 @@
     "repositories": {
         "drupal": {
             "type": "composer",
-            "url": "https://packages.drupal.org/8"
+            "url": "https://packages.drupal.org/8",
+            "exclude": ["drupal/domain_group"]
+        },
+        "drupal/domain_group": {
+            "type": "vcs",
+            "url": "https://git.drupalcode.org/issue/domain_group-3276172.git"
         }
     },
     "require": {


### PR DESCRIPTION
Adds a list of domains that lando will fire up. These can be used in testing by the lando container user.

Also runs a script. It seems composer has put it there by the time it runs. That adds the .example.com domains for localhost that are expected by the phpunit tests in `domain_group` module (seperate PR for adding the vcs repo for that).