### PR TITLE
Changes to group_content_menu source

### DIFF
--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -6,10 +6,10 @@ name: Test LocalGov Microsites localgovdrupal/localgov_microsites_project projec
 on:
   push:
     branches:
-      - '1.x'
+      - '2.x'
   pull_request:
     branches:
-      - '1.x'
+      - '2.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_microsites_project
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '1.x'
+          - '2.x'
         drupal-version:
           - '~9.3'
         php-version:
@@ -57,7 +57,7 @@ jobs:
       - name: Get the latest tagged release for branch version
         run: |
           LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${GIT_BASE%'.x'} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
-          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=1.x-dev; fi
+          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=2.x-dev; fi
           echo "LATEST_RELEASE=${LATEST_RELEASE}" >> $GITHUB_ENV
 
       - name: Cached workspace
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '1.x'
+          - '2.x'
         drupal-version:
           - '~9.3'
         php-version:
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '1.x'
+          - '2.x'
         drupal-version:
           - '~9.3'
         php-version:
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '1.x'
+          - '2.x'
         drupal-version:
           - '~9.3'
         php-version:

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -29,7 +29,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:
@@ -93,7 +92,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:
@@ -129,7 +127,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:
@@ -164,7 +161,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,11 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8",
-            "exclude": ["drupal/domain_group", "drupal/group_content_menu", "drupal/group_permissions"]
+            "exclude": ["drupal/domain_group", "drupal/group_permissions"]
         },
         "drupal/domain_group": {
             "type": "vcs",
             "url": "https://git.drupalcode.org/sandbox/ekes-3278349.git"
-        },
-        "drupal/group_content_menu": {
-            "type": "vcs",
-            "url": "https://git.drupalcode.org/issue/group_content_menu-3315163.git"
         },
         "drupal/group_permissions": {
           "type": "vcs",


### PR DESCRIPTION
This issue fork of group_content_menu has been merged with the 3.0.x branch recently: https://git.drupalcode.org/issue/group_content_menu-3315163.git.  This means we can now use drupal/group_content_menu:3.0.x-dev instead of the fork.

@see https://www.drupal.org/node/3315163