### PR TITLE
ci: add phpstan updates

### DIFF
--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -78,7 +78,7 @@ tooling:
   composer:
     service: appserver
     cmd: /usr/local/bin/composer
-  deprecated:
+  sca:
     service: appserver
     cmd: 'bash -c "/app/bin/phpstan analyse -c /app/phpstan.neon /app/web/profiles/contrib/localgov_*/ /app/web/modules/contrib/localgov_*/  /app/web/themes/contrib/localgov_*"'
   drush:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,9 @@
         "mglaman/phpstan-drupal": "^1.1",
         "phpspec/prophecy-phpunit": "^2",
         "phpstan/phpstan": "^1.5",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "spaze/phpstan-disallowed-calls": "^3.4"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,561 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_blogs/localgov_blogs.module
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_blogs/localgov_blogs.module
+
+		-
+			message: "#^Class GroupInterface not found\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_blogs/localgov_blogs.module
+
+		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.install
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/localgov_directories.module
+
+		-
+			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_db/tests/Kernel/InstallTest.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/localgov_directories_location.module
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_location/src/ProximitySearchSetup.php
+
+		-
+			message: "#^Parameter \\$map of function localgov_directories_or_localgov_openreferral_mapping_delete\\(\\) has invalid type Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMappingInterface\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Parameter \\$map of function localgov_directories_or_localgov_openreferral_mapping_insert\\(\\) has invalid type Drupal\\\\localgov_openreferral\\\\Entity\\\\PropertyMappingInterface\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/localgov_directories_or.module
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_directories/modules/localgov_directories_or/src/FacetMapping.php
+
+		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/ConfigurationHelper.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/ConfigurationHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$callback of function array_reduce expects callable\\(array\\<string\\>, Drupal\\\\Core\\\\Entity\\\\EntityInterface\\)\\: array\\<string\\>, Closure\\(array, Drupal\\\\node\\\\NodeInterface\\)\\: array\\<string\\> given\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/Block/ChannelSearchBlock.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\localgov_directories\\\\Plugin\\\\PreviewLinkAutopopulate\\\\DirectoryChannel\\:\\:\\$entityTypeManager\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/PreviewLinkAutopopulate/DirectoryChannel.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\localgov_directories\\\\Plugin\\\\PreviewLinkAutopopulate\\\\DirectoryChannel\\:\\:getEntity\\(\\)\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/PreviewLinkAutopopulate/DirectoryChannel.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+
+		-
+			message: "#^Variable \\$bundle might not be defined\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+
+		-
+			message: "#^Variable \\$query in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/src/Plugin/facets/query_type/LocalGovDirectoriesQueryType.php
+
+		-
+			message: "#^Method Drupal\\\\Tests\\\\BrowserTestBase\\:\\:drupalLogout\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Functional/FacetsTest.php
+
+		-
+			message: "#^Call to method Drupal\\\\Tests\\\\UnitTestCase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			count: 1
+			path: web/modules/contrib/localgov_directories/tests/src/Unit/FacetPreprocessTest.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_events/localgov_events.module
+
+		-
+			message: "#^Call to static method load\\(\\) on an unknown class DateFormat\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/localgov_forms.tokens.inc
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/modules/localgov_forms_example_liberty_create_integration/localgov_forms_example_liberty_create_integration.module
+
+		-
+			message: "#^Variable \\$webform_submission in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/modules/localgov_forms_example_liberty_create_integration/localgov_forms_example_liberty_create_integration.module
+
+		-
+			message: "#^Variable \\$latitude on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/AddressLookup.php
+
+		-
+			message: "#^Variable \\$longitude on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/AddressLookup.php
+
+		-
+			message: "#^Variable \\$unique_id on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/AddressLookup.php
+
+		-
+			message: "#^Variable \\$uprn on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/AddressLookup.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/Element/AddressLookupElement.php
+
+		-
+			message: "#^Method Drupal\\\\localgov_forms\\\\Element\\\\AddressLookupElement\\:\\:valueCallback\\(\\) should return mixed but return statement is missing\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_forms/src/Element/AddressLookupElement.php
+
+		-
+			message: "#^Call to static method Drupal\\\\Component\\\\Utility\\\\Html\\:\\:escape\\(\\) with incorrect case\\: Escape$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_address/tests/Functional/AddressFormsTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$new_config$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/MigrateDisplayModes.php
+
+		-
+			message: "#^Variable \\$new_base_array might not be defined\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/MigrateDisplayModes.php
+
+		-
+			message: "#^Variable \\$new_config in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/src/MigrateDisplayModes.php
+
+		-
+			message: "#^Variable \\$url might not be defined\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/src/Element/AutocompleteAddress.php
+
+		-
+			message: "#^Parameter \\#2 \\$callback of function uasort expects callable\\(Drupal\\\\Core\\\\Entity\\\\EntityInterface, Drupal\\\\Core\\\\Entity\\\\EntityInterface\\)\\: int, Closure\\(Drupal\\\\geocoder\\\\Entity\\\\GeocoderProvider, Drupal\\\\geocoder\\\\Entity\\\\GeocoderProvider\\)\\: \\(\\-1\\|0\\|1\\) given\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_geo/modules/localgov_geo_update/tests/modules/localgov_geo_update_to_geo_test/src/Plugin/Field/FieldWidget/AutocompleteAddress.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 4
+			path: web/modules/contrib/localgov_microsites_group/localgov_microsites_group.module
+
+		-
+			message: "#^Class EntityFormInterface not found\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/localgov_microsites_group.module
+
+		-
+			message: "#^Variable \\$active in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/localgov_microsites_group.module
+
+		-
+			message: "#^Variable \\$active_domain in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/localgov_microsites_group.module
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/localgov_microsites_blogs.module
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$blog_channel1\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$blog_channel2\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$domain1\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$domain2\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$post1\\.$#"
+			count: 5
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_blogs\\\\Functional\\\\MicrositeBlogsContentTest\\:\\:\\$post2\\.$#"
+			count: 5
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_blogs/tests/src/Functional/MicrositeBlogsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$channel1\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$channel2\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$domain1\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$domain2\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$pages1\\.$#"
+			count: 10
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_directories\\\\Functional\\\\MicrositeDirectoryContentTest\\:\\:\\$pages2\\.$#"
+			count: 10
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeDirectoryFacetTest\\:\\:\\$domain1\\.$#"
+			count: 6
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryFacetTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeDirectoryFacetTest\\:\\:\\$domain2\\.$#"
+			count: 4
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryFacetTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeDirectoryFacetTest\\:\\:\\$user\\.$#"
+			count: 5
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryFacetTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventContentTest\\:\\:\\$domain1\\.$#"
+			count: 7
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventContentTest\\:\\:\\$domain2\\.$#"
+			count: 7
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventContentTest\\:\\:\\$pages1\\.$#"
+			count: 18
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventContentTest\\:\\:\\$pages2\\.$#"
+			count: 18
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventViewAccesTest\\:\\:\\$allTestGroups\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventViewAccesTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventViewAccesTest\\:\\:\\$domain\\.$#"
+			count: 5
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventViewAccesTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_events\\\\Functional\\\\MicrositeEventViewAccesTest\\:\\:\\$group\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventViewAccesTest.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
+
+		-
+			message: "#^Variable \\$group in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_group_term_ui/src/Controller/GroupTermUiController.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$article1\\.$#"
+			count: 10
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$article2\\.$#"
+			count: 10
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$domain1\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$domain2\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$newsroom1\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeNewsContentTest\\:\\:\\$newsroom2\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+
+		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/ContentTypeHelper.php
+
+		-
+			message: "#^Parameter \\#3 \\$favicon_entity of method Drupal\\\\localgov_microsites_group\\\\DomainSettingsHelper\\:\\:setFavicon\\(\\) expects Drupal\\\\file\\\\FileInterface, Drupal\\\\Core\\\\Entity\\\\EntityInterface\\|null given\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/DomainSettingsHelper.php
+
+		-
+			message: "#^Parameter \\$plugin_manager_domain_group_settings of method Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupConfigAdd\\:\\:__construct\\(\\) has invalid type Drupal\\\\domain_group\\\\Plugin\\\\DomainGroupSettingsManager\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupConfigAdd.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd\\:\\:\\$privateTempStoreFactory\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupContentAdd.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd\\:\\:getEntity\\(\\)\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupContentAdd.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd\\:\\:getRequest\\(\\)\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupContentAdd.php
+
+		-
+			message: "#^Call to an undefined method Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd\\:\\:t\\(\\)\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupContentAdd.php
+
+		-
+			message: "#^Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd\\:\\:actions\\(\\) calls parent\\:\\:actions\\(\\) but Drupal\\\\localgov_microsites_group\\\\Form\\\\DomainGroupContentAdd does not extend any class\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Form/DomainGroupContentAdd.php
+
+		-
+			message: "#^Variable \\$plugin_id might not be defined\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/GroupDefaultContent.php
+
+		-
+			message: "#^Parameter \\$domain_group_resolver of method Drupal\\\\localgov_microsites_group\\\\Plugin\\\\Block\\\\MicrositeTasksBlock\\:\\:__construct\\(\\) has invalid type Drupal\\\\domain_group\\\\DomainGroupResolverInterface\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Plugin/Block/MicrositeTasksBlock.php
+
+		-
+			message: "#^Variable \\$active in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/src/Plugin/search_api/processor/EntityAccess.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupAdminAccessTest\\:\\:\\$adminUser1\\.$#"
+			count: 5
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupAdminAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupAdminAccessTest\\:\\:\\$adminUser2\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupAdminAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupAdminAccessTest\\:\\:\\$memberUser1\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupAdminAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupAdminAccessTest\\:\\:\\$memberUser2\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupAdminAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupAdminAccessTest\\:\\:\\$ownerUser\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupAdminAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$adminUser1\\.$#"
+			count: 8
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$adminUser2\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$controller\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$memberUser1\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$memberUser2\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupContentTypeAccessTest\\:\\:\\$ownerUser\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupContentTypeAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupInvitationAccessTest\\:\\:\\$memberUser\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupInvitationAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\GroupInvitationAccessTest\\:\\:\\$ownerUser\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/GroupInvitationAccessTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeCachingTest\\:\\:\\$domain\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeCachingTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeCachingTest\\:\\:\\$group\\.$#"
+			count: 3
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeCachingTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeSitewideSearchTest\\:\\:\\$domain1\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeSitewideSearchTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeSitewideSearchTest\\:\\:\\$domain2\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeSitewideSearchTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeSitewideSearchTest\\:\\:\\$pages1\\.$#"
+			count: 6
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeSitewideSearchTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\MicrositeSitewideSearchTest\\:\\:\\$pages2\\.$#"
+			count: 4
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/MicrositeSitewideSearchTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\ModuleSettingsFormTest\\:\\:\\$memberUser\\.$#"
+			count: 2
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/ModuleSettingsFormTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Functional\\\\ModuleSettingsFormTest\\:\\:\\$ownerUser\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Functional/ModuleSettingsFormTest.php
+
+		-
+			message: "#^@covers value \\\\Drupal\\\\localgov_microsites_group\\\\GroupPermisisonsHelper references an invalid class or function\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Kernel/ContentTypeHelperTest.php
+
+		-
+			message: "#^Access to an undefined property Drupal\\\\Tests\\\\localgov_microsites_group\\\\Kernel\\\\ContentTypeHelperTest\\:\\:\\$group\\.$#"
+			count: 7
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Kernel/ContentTypeHelperTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method Drupal\\\\KernelTests\\\\Core\\\\Entity\\\\EntityKernelTestBase\\:\\:createUser\\(\\) expects string\\|null, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: web/modules/contrib/localgov_microsites_group/tests/src/Kernel/SettingsFormAccessTest.php
+
+		-
+			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/modules/localgov_search_db/tests/Kernel/InstallTest.php
+
+		-
+			message: "#^Call to method Drupal\\\\KernelTests\\\\KernelTestBase\\:\\:setUp\\(\\) with incorrect case\\: setup$#"
+			count: 1
+			path: web/modules/contrib/localgov_search/tests/src/Kernel/ContentTypesAddedToSearchTest.php
+
+		-
+			message: "#^Class NodeInterface not found\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_microsites_base/localgov_microsites_base.theme
+
+		-
+			message: "#^Variable \\$image_style might not be defined\\.$#"
+			count: 1
+			path: web/themes/contrib/localgov_microsites_base/localgov_microsites_base.theme

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,24 @@
+includes:
+  - phpstan-baseline.neon
+  - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
+  - vendor/spaze/phpstan-disallowed-calls/disallowed-insecure-calls.neon
+
 parameters:
-  # we don't set a level so that we check deprecations only, and
-  # not to highlight unknown classes which are from composer suggestions.
+  level: 1
   customRulesetUsed: true
   reportUnmatchedIgnoredErrors: false
+  checkFunctionArgumentTypes: true
+
+  drupal:
+    rules:
+      classExtendsInternalClassRule: false
+
+  strictRules:
+    allRules: false
+    strictCalls: true
+
   # Ignore phpstan-drupal extension's rules.
   ignoreErrors:
     - '#\Drupal calls should be avoided in classes, use dependency injection instead#'
@@ -11,6 +27,8 @@ parameters:
     - '#Plugin manager has cache backend specified but does not declare cache tags.#'
     # new static() is a best practice in Drupal, so we cannot fix that.
     - '#^Unsafe usage of new static#'
+    # Disable PHPUnit dynamic call until core decision - https://www.drupal.org/project/drupal/issues/3029358
+    - '#Dynamic call to static method PHPUnit\\Framework\\.*#'
     # FIXME: ignore Drupal 12 deprecations
     - '#Class Drupal\\localgov_forms\\Element\\AddressLookupElement extends deprecated class Drupal\\Core\\Render\\Element\\FormElement#'
     - '#Call to deprecated method renderPlain\(\) of interface Drupal\\Core\\Render\\RendererInterface#'


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This PR adds the same PHPStan checks as the main project as well as adding an extra quality gate check to the static analysis check to make sure there are no disallowed/dangerous/insecure calls in the codebase, such as:

- `var_dump()`
- `print_r()`
- `phpinfo()`
- `exec()`, `shell_exec()`, etc...

A baseline PHPStan file has also been generated, and the errors reported within can be looked at over time.

## How to test

Run `lando sca`
