### PR TITLE
feat: fail workflow if composer patches fail

### DIFF
--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -23,6 +23,8 @@ jobs:
   build:
     name: Install LocalGov Microsites
     runs-on: ubuntu-latest
+    env:
+      COMPOSER_EXIT_ON_PATCH_FAILURE: '1'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This is a workflow-only change, to make composer patch failures more visible like with the main project