### PR TITLE
Don't allow Composer plugin tbachert/spi to run by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,12 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "php-http/discovery": true
+            "tbachert/spi": false
         }
     },
     "extra": {


### PR DESCRIPTION
Fixes #74 

Don't allow Composer plugin tbachert/spi to run by default.

We have already done this for LocalGov Drupal (https://github.com/localgovdrupal/localgov_project/pull/192).