### PR TITLE
4.0.3 release

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -28,7 +28,9 @@ mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: ""
 web_environment: []
-nodejs_version: "16"
+nodejs_version: "20"
+corepack_enable: true
+
 
 # Key features of ddev's config.yaml:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ ddev ssh
 phpunit --filter=myTestName
 ```
 
-
 ## Maintainers
 
 This project is currently maintained by:

--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,12 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "php-http/discovery": true
+            "tbachert/spi": false
         }
     },
     "extra": {


### PR DESCRIPTION
Keen to avoid the question about tbachert/spi on install: 


```
tbachert/spi contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "tbachert/spi" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```
